### PR TITLE
Add img_dir_txt option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Install
 
-You can install it using `packer`
+You can install it using [packer](https://github.com/wbthomason/packer.nvim)
 
 ```lua
 use 'ekickx/clipboard-image.nvim'
@@ -22,7 +22,8 @@ use 'ekickx/clipboard-image.nvim'
 
 ```lua
 require'clipboard-image'.setup {
-  img_dir = 'img',
-  paste_img_name = tostring(os.date("%Y-%m-%d-%H-%M-%S"))
+  img_dir = "return 'img'",
+  img_dir_txt = "return 'img'",
+  img_name = "return os.date('%Y-%m-%d-%H-%M-%S')"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,17 +13,45 @@ You can install it using [packer](https://github.com/wbthomason/packer.nvim)
 use 'ekickx/clipboard-image.nvim'
 ```
 
-# Command
+# Use
 
-- `:PasteImg`
-- `:DeleteImg`
+- `:PasteImg` or `:lua require'clipboard-image.paste'.paste_img()`
+- `:DeleteImg` or `:lua require'clipboard-image.delete'.delete()`
 
-# Default config
+# Config
+
+## Default config
+
+After the plugin installed, you can already use it with the default config like this:
 
 ```lua
 require'clipboard-image'.setup {
   img_dir = "return 'img'",
   img_dir_txt = "return 'img'",
   img_name = "return os.date('%Y-%m-%d-%H-%M-%S')"
+}
+```
+
+## Config example
+
+How this plugin loads config is using [`loadstring()`](https://www.lua.org/manual/5.1/manual.html#pdf-loadstring), so your config must have a return value.
+
+For example, I use [11ty](https://www.11ty.dev/) to generate a static site from my markdown. I want to save my image on `assets/img` And instead of based on date, I want my image's name to be `image1`, `image2`, etc. But I want the pasted text to be `/img/image1` instead of `assets/img/image1`. So more or less the config will be like this:
+
+```lua
+require'clipboard-image'.setup {
+  img_dir = "return 'assets/img'",
+  img_dir_txt = "return '/img'",
+  img_name = [[
+  local index = 1
+  for output in io.popen('ls assets/img'):lines() do
+    if output == 'image'..index..'.png' then
+      index = index + 1
+    else
+      break
+    end
+  end
+  return 'image'..index
+  ]]
 }
 ```

--- a/lua/clipboard-image.lua
+++ b/lua/clipboard-image.lua
@@ -1,13 +1,19 @@
 local M = {}
 local cmd = vim.cmd
+
 local config = {
-  img_dir = 'img',
-  paste_img_name = tostring(os.date("%Y-%m-%d-%H-%M-%S")),
+  img_dir = "return 'img'",
+  img_dir_txt = "return 'img'",
+  img_name = "return os.date('%Y-%m-%d-%H-%M-%S')"
 }
 
 M.setup = function (opts)
-  config = vim.tbl_extend('force', config, opts or {})
+  M.merge_config(config, opts)
   M.create_command()
+end
+
+M.merge_config = function (old_opts, new_opts)
+  config = vim.tbl_extend('force', old_opts, new_opts or {})
 end
 
 M.get_config = function ()

--- a/lua/clipboard-image/delete.lua
+++ b/lua/clipboard-image/delete.lua
@@ -1,17 +1,18 @@
 local M = {}
+local fn = vim.fn
 
 M.delete_img = function ()
-  local start_line = vim.fn.getpos("'<")[2]
-  local end_line = vim.fn.getpos("'>")[2]
-  local start_col = vim.fn.getpos("'<")[3]
-  local end_col = vim.fn.getpos("'>")[3]
+  local start_line = fn.getpos("'<")[2]
+  local end_line = fn.getpos("'>")[2]
+  local start_col = fn.getpos("'<")[3]
+  local end_col = fn.getpos("'>")[3]
 
-  local img_path = vim.fn.getline(start_line, end_line)[1]:sub(start_col, end_col)
+  local img_path = fn.getline(start_line, end_line)[1]:sub(start_col, end_col)
 
   -- Delete image file
-  vim.fn.delete(vim.fn.fnameescape(img_path))
+  fn.delete(fn.fnameescape(img_path))
   -- Delete image text
-  vim.cmd("s/"..vim.fn.escape(img_path, "/").."/")
+  vim.cmd("s/"..fn.escape(img_path, "/").."/")
 end
 
 return M

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -1,23 +1,23 @@
 local M = {}
 local cmd = vim.cmd
-local config = require'clipboard-image'.get_config()
+local fn = vim.fn
 
 -- Check OS and display server
-local check_type = '' -- var to store command to check clipboard content's type
-local cmd_clip = '' -- var to store command to paste clipboard content
+local cmd_check = '' -- var to store command to check clipboard content's type
+local cmd_paste = '' -- var to store command to paste clipboard content
 if package.config:sub(1,1) == '/' then
   if os.getenv('XDG_SESSION_TYPE') == 'x11' then
-    check_type = 'xclip -selection clipboard -o -t TARGETS'
-    cmd_clip = 'xclip -selection clipboard -t image/png -o >'
+    cmd_check = 'xclip -selection clipboard -o -t TARGETS'
+    cmd_paste = 'xclip -selection clipboard -t image/png -o >'
   elseif os.getenv('XDG_SESSION_TYPE') == 'wayland' then
-    check_type = 'wl-paste --list-types'
-    cmd_clip = 'wl-paste --no-newline --type image/png >'
+    cmd_check = 'wl-paste --list-types'
+    cmd_paste = 'wl-paste --no-newline --type image/png >'
   end
 end
 
--- Check whether the clipboard content is image or not
+-- Function that return clipboard content's type
 local clipboard_type = function ()
-  local command = io.popen(check_type)
+  local command = io.popen(cmd_check)
   local outputs = {}
 
   -- store output to outputs's table
@@ -27,26 +27,43 @@ local clipboard_type = function ()
   return outputs
 end
 
--- Paste image on linux device
-local paste_on_linux = function ()
-  if not vim.tbl_contains(clipboard_type(), 'image/png') then
-    print('There is no image data in clipboard')
-  else
-    local img_path = config['img_dir']..'/'..config['paste_img_name']..'.png'
-
-    -- create img_dir if doesn't exist
-    if vim.fn.isdirectory(config['img_dir']) == 0 then
-      vim.fn.mkdir(config['img_dir'], 'p')
-    end
-
-    os.execute(cmd_clip..img_path) -- paste image to img_path
-    cmd("normal a"..img_path) -- insert img_path
+-- Function that create dir if it doesn't exist
+local create_dir = function (dir)
+  -- create img_dir if doesn't exist
+  if fn.isdirectory(dir) == 0 then
+    fn.mkdir(dir, 'p')
   end
 end
 
+-- Function that paste image to *path*
+local paste_img_to = function (path)
+  os.execute(cmd_paste..path)
+end
+
+-- Create image's path from dir and img_name
+local img_path = function (dir, img)
+  return dir..'/'..img..'.png'
+end
+
 M.paste_img = function ()
-  if package.config:sub(1,1) == '/' then
-    paste_on_linux()
+  -- load config
+  local config = require'clipboard-image'.get_config()
+  local img_dir = loadstring(config.img_dir)
+  local img_dir_txt = loadstring(config.img_dir_txt)
+  local img_name = loadstring(config.img_name)
+
+  -- check wether clipboard content's image or not
+  if not vim.tbl_contains(clipboard_type(), 'image/png') then
+    print('There is no image data in clipboard')
+  else
+    -- create img_dir if it doesn't exist
+    create_dir(img_dir())
+
+    -- paste image to its path
+    paste_img_to(img_path(img_dir(), img_name()))
+
+    -- insert image's path
+    cmd("normal a"..img_path(img_dir_txt(), img_name()))
   end
 end
 

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -48,22 +48,28 @@ end
 M.paste_img = function ()
   -- load config
   local config = require'clipboard-image'.get_config()
-  local img_dir = loadstring(config.img_dir)
-  local img_dir_txt = loadstring(config.img_dir_txt)
-  local img_name = loadstring(config.img_name)
+
+  local load_img_dir = loadstring(config.img_dir)
+  local img_dir = load_img_dir()
+
+  local load_img_dir_txt = loadstring(config.img_dir_txt)
+  local img_dir_txt = load_img_dir_txt()
+
+  local load_img_name = loadstring(config.img_name)
+  local img_name = load_img_name()
 
   -- check wether clipboard content's image or not
   if not vim.tbl_contains(clipboard_type(), 'image/png') then
     print('There is no image data in clipboard')
   else
     -- create img_dir if it doesn't exist
-    create_dir(img_dir())
+    create_dir(img_dir)
 
     -- paste image to its path
-    paste_img_to(img_path(img_dir(), img_name()))
+    paste_img_to(img_path(img_dir, img_name))
 
     -- insert image's path
-    cmd("normal a"..img_path(img_dir_txt(), img_name()))
+    cmd("normal a"..img_path(img_dir_txt, img_name))
   end
 end
 


### PR DESCRIPTION
This pr is working on #2. 
It's add option to custom pasted text of `img_dir`. As shown in the gif, the image is saved in `assets/img` but the pasted text of `img_dir` is `/img`

![Peek 2021-02-11 15-53](https://user-images.githubusercontent.com/26477782/107617111-ded4c880-6c81-11eb-96f5-b1633a4b1a74.gif)
