### PR TITLE
feat: filetype specific config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,21 @@ use 'ekickx/clipboard-image.nvim'
 
 After the plugin installed, you can already use it without configuring it.
 
+Config can be different for different filetype. The `default` table is for all filetype. For specifiec filetype, you can create a new table with its name is the same as the filetype's name. To know the filetype's name you can use `:lua print(vim.bo.filetype)`.
+
 The default config is like this:
 
 ```lua
 require'clipboard-image'.setup {
-  img_dir = 'img',
-  img_dir_txt = 'img',
-  img_name = function () return os.date('%Y-%m-%d-%H-%M-%S') end,
-  affix = '%s'
+  default = {
+    img_dir = 'img',
+    img_dir_txt = 'img',
+    img_name = function () return os.date('%Y-%m-%d-%H-%M-%S') end,
+    affix = '%s'
+  },
+  markdown = {
+    affix = '![](%s)'
+  },
 }
 ```
 
@@ -48,21 +55,25 @@ For example, I use [11ty](https://www.11ty.dev/) to generate a static site from 
 
 ```lua
 require'clipboard-image'.setup {
-  img_dir = 'src/assets/img',
-  img_dir_txt = '/assets/img',
-  img_name = function ()
-    local img_dir = require'clipboard-image'.get_config().img_dir()
-    local index = 1
-    for output in io.popen('ls '..img_dir):lines() do
-      if output == 'image'..index..'.png' then
-        index = index + 1
-      else
-        break
+  default = {
+    img_name = function ()
+      local img_dir = require'clipboard-image.config'.get_config().img_dir()
+      local index = 1
+      for output in io.popen('ls '..img_dir):lines() do
+        if output == 'image'..index..'.png' then
+          index = index + 1
+        else
+          break
+        end
       end
-    end
-    return 'image'..index
-  end,
-  affix = '![](%s)',
+      return 'image'..index
+    end,
+  },
+  markdown = {
+    img_dir = 'src/assets/img',
+    img_dir_txt = '/assets/img',
+    affix = '![](%s)',
+  },
 }
 ```
 

--- a/doc/clipboard-image.txt
+++ b/doc/clipboard-image.txt
@@ -38,11 +38,11 @@ Lua Functions~                                      *clipboard-image-functions*
     See |clipboard-image-config| for more info about the config's options.
 
 
-`clipboard-image.get_config()`                   *clipboard-image.get_config()*
+`clipboard-image.config.get_config()`     *clipboard-image.config.get_config()*
     This function return the value of this plugin's current config.
 
     If you want to print the value of this function, you can use this command: 
-    `:lua print(vim.inspect(require'clipboard-image'.get_config()))`
+    `:lua print(vim.inspect(require'clipboard-image'.config.get_config()))`
 
 `clipboard-image.paste.paste_img()`         *clipboard-image.paste.paste_img()*
 
@@ -52,6 +52,11 @@ Lua Functions~                                      *clipboard-image-functions*
 
 ===============================================================================
 CONFIGURATION                                          *clipboard-image-config*
+
+Config can be different for different filetype. The `default` table is for all
+filetype. For specifiec filetype, you can create a new table with its name is
+the same as the filetype's name. To know the filetype's name you can use
+`:lua print(vim.bo.filetype)` . See also |clipboard-image-config-example|.
 
 Options~                                       *clipboard-image-config-options*
 
@@ -92,6 +97,8 @@ img_affix                                    *clipboard-image-config-img_affix*
 
 Example~                                       *clipboard-image-config-example*
 
+See also |clipboard-image-config|
+
 For example, I use 11ty to generate a static site from my markdown. I want to
 save my image on 'src/assets/img' And instead of based on date, I want my
 image's name to be image1, image2, etc. But I want the pasted text to be
@@ -100,21 +107,25 @@ like this:
 
 >
   require'clipboard-image'.setup {
-    img_dir = 'src/assets/img',
-    img_dir_txt = '/assets/img',
-    img_name = function ()
-      local img_dir = require'clipboard-image'.get_config().img_dir()
-      local index = 1
-      for output in io.popen('ls '..img_dir):lines() do
-	if output == 'image'..index..'.png' then
-	  index = index + 1
-	else
-	  break
+    default = {
+      img_name = function ()
+	local img_dir = require'clipboard-image.config'.get_config().img_dir()
+	local index = 1
+	for output in io.popen('ls '..img_dir):lines() do
+	  if output == 'image'..index..'.png' then
+	    index = index + 1
+	  else
+	    break
+	  end
 	end
-      end
-      return 'image'..index
-    end,
-    affix = '![](%s)',
+	return 'image'..index
+      end,
+    },
+    markdown = {
+      img_dir = 'src/assets/img',
+      img_dir_txt = '/assets/img',
+      affix = '![](%s)',
+    },
   }
 <
 

--- a/doc/tags
+++ b/doc/tags
@@ -11,7 +11,7 @@ clipboard-image-config-options	clipboard-image.txt	/*clipboard-image-config-opti
 clipboard-image-functions	clipboard-image.txt	/*clipboard-image-functions*
 clipboard-image-requirement	clipboard-image.txt	/*clipboard-image-requirement*
 clipboard-image-usage	clipboard-image.txt	/*clipboard-image-usage*
-clipboard-image.get_config()	clipboard-image.txt	/*clipboard-image.get_config()*
+clipboard-image.config.get_config()	clipboard-image.txt	/*clipboard-image.config.get_config()*
 clipboard-image.paste.paste_img()	clipboard-image.txt	/*clipboard-image.paste.paste_img()*
 clipboard-image.setup()	clipboard-image.txt	/*clipboard-image.setup()*
 clipboard-image.txt	clipboard-image.txt	/*clipboard-image.txt*

--- a/lua/clipboard-image/config.lua
+++ b/lua/clipboard-image/config.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+local config = {
+  default = {
+    img_dir = 'img',
+    img_dir_txt = 'img',
+    img_name = function () return os.date('%Y-%m-%d-%H-%M-%S') end,
+    affix = '%s'
+  },
+  markdown = {
+    affix = '![](%s)'
+  },
+}
+
+M.merge_config = function (old_opts, new_opts)
+  return vim.tbl_extend('force', old_opts, new_opts or {})
+end
+
+M.get_config = function ()
+  return config
+end
+
+return M

--- a/lua/clipboard-image/config.lua
+++ b/lua/clipboard-image/config.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local config = {
+M.config = {
   default = {
     img_dir = 'img',
     img_dir_txt = 'img',
@@ -13,11 +13,11 @@ local config = {
 }
 
 M.merge_config = function (old_opts, new_opts)
-  return vim.tbl_extend('force', old_opts, new_opts or {})
+  return vim.tbl_deep_extend('force', old_opts, new_opts or {})
 end
 
 M.get_config = function ()
-  return config
+  return M.config
 end
 
 return M

--- a/lua/clipboard-image/init.lua
+++ b/lua/clipboard-image/init.lua
@@ -3,8 +3,7 @@ local M = {}
 local conf_module = require'clipboard-image.config'
 
 M.setup = function (opts)
-  local config = conf_module.get_config()
-  config = conf_module.merge_config(config, opts)
+  conf_module.config = conf_module.merge_config(conf_module.config, opts)
 end
 
 return M

--- a/lua/clipboard-image/init.lua
+++ b/lua/clipboard-image/init.lua
@@ -1,22 +1,10 @@
 local M = {}
 
-local config = {
-  img_dir = 'img',
-  img_dir_txt = 'img',
-  img_name = function () return os.date('%Y-%m-%d-%H-%M-%S') end,
-  affix = '%s'
-}
-
-local merge_config = function (old_opts, new_opts)
-  return vim.tbl_extend('force', old_opts, new_opts or {})
-end
+local conf_module = require'clipboard-image.config'
 
 M.setup = function (opts)
-  config = merge_config(config, opts)
-end
-
-M.get_config = function ()
-  return config
+  local config = conf_module.get_config()
+  config = conf_module.merge_config(config, opts)
 end
 
 return M

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -1,6 +1,7 @@
 local M = {}
 local cmd = vim.cmd
 local fn = vim.fn
+local conf_module = require'clipboard-image.config'
 
 -- Check OS and display server
 -- https://vi.stackexchange.com/a/2577/33116
@@ -75,11 +76,19 @@ end
 
 M.paste_img = function ()
   -- Check wether clipboard content is image or not
-  if is_clipboard_img(get_clip_content(cmd_check)) ~= true then
+  local content = get_clip_content(cmd_check)
+  if is_clipboard_img(content) ~= true then
     print('There is no image data in clipboard')
   else
-    -- Load config
-    local conf_toload = require'clipboard-image'.get_config()
+    -- Load config [[
+    local conf_toload = conf_module.get_config()
+
+    -- Merge default config with current filetype config
+    local filetype = vim.bo.filetype
+    local def_conf, ft_conf = conf_toload.default, conf_toload[filetype]
+    conf_toload = conf_module.merge_config(def_conf, ft_conf)
+
+    -- Assign conf_toload's value to conf table
     local conf = {}
     for key, value in pairs(conf_toload) do
       -- If config is a function than load it first
@@ -89,6 +98,7 @@ M.paste_img = function ()
         conf[key] = value
       end
     end
+    -- ]]
 
     -- Create img_dir if it doesn't exist
     create_dir(conf.img_dir)


### PR DESCRIPTION
So yeah now you can configure this plugin like this:

```lua
require'clipboard-image'.setup {
  default = {
    img_dir = 'img',
    img_dir_txt = 'img',
    img_name = function () return os.date('%Y-%m-%d-%H-%M-%S') end,
    affix = '%s'
  },
  markdown = {
    affix = '![](%s)'
  },
}
```

The `default` table is the default config for all filetype. You can configure a specific filetype by making a table of it. To know the filetype of the current buffer, run `:lua print(vim.bo.filetype)`