### PR TITLE
Initial support for Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Requirement
 
-This plugin currently only supports Windows and Linux.
+This plugin currently only supports Windows, Linux and Mac OS.
 
 On Linux, you will need:
 
 - `xclip` for x11
 - `wl-clipboard` for wayland
+
+On Mac OS you will need [pngpaste](https://github.com/jcsalterego/pngpaste).
 
 # Install
 

--- a/doc/clipboard-image.txt
+++ b/doc/clipboard-image.txt
@@ -15,8 +15,8 @@ REQUIREMENTS                                      *clipboard-image-requirement*
 
 Clipboard-image only works on Neovim version that support lua.
 
-For linux user you also need xclip if you are on X11 or wl-clipboard if you are
-on wayland.
+For linux you also need xclip if you are on X11 or wl-clipboard if you are
+on wayland. Mac OS users need to install pngpaste.
 
 ===============================================================================
 USAGE                                                   *clipboard-image-usage*
@@ -39,7 +39,7 @@ Lua Functions~                                      *clipboard-image-functions*
 
 
 `clipboard-image.config.get_config()`     *clipboard-image.config.get_config()*
-    This function return the value of this plugin's current config.
+    This function returns the value of this plugin's current config.
 
     If you want to print the value of this function, you can use this command: 
     `:lua print(vim.inspect(require'clipboard-image'.config.get_config()))`
@@ -47,7 +47,7 @@ Lua Functions~                                      *clipboard-image-functions*
 `clipboard-image.paste.paste_img()`         *clipboard-image.paste.paste_img()*
 
     Paste your clipboard image with this function. This function can also
-    receive optional argument like this (see |clipboard-image-config-options|):
+    receive optional arguments like this (see |clipboard-image-config-options|):
     ```
     :lua require'clipboard-image.paste'.paste_img {
       img_dir = 'src/assets/img'

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -22,6 +22,9 @@ if get_os() == 'Linux' then
     cmd_check = 'wl-paste --list-types'
     cmd_paste = 'wl-paste --no-newline --type image/png > %s'
   end
+elseif get_os() == 'Darwin' then
+  cmd_check = 'pngpaste -b 2>&1'
+  cmd_paste = 'pngpaste %s'
 elseif get_os() == 'Windows' then
   cmd_check = 'Get-Clipboard -Format Image'
   cmd_paste = '$content = '..cmd_check..';$content.Save(\'%s\', \'png\')'
@@ -44,6 +47,8 @@ end
 -- Function to check wether clipboard content is image or not
 local is_clipboard_img = function (content)
   if get_os() == 'Linux' and vim.tbl_contains(content, 'image/png') then
+    return true
+  elseif get_os() == 'Darwin' and string.sub(content[1], 1, 9) == 'iVBORw0KG' then -- Magic png number in base64
     return true
   elseif get_os() == 'Windows' and content ~= nil then
     return true
@@ -106,7 +111,7 @@ M.paste_img = function (opts)
     -- Create img_dir if it doesn't exist
     create_dir(conf.img_dir)
 
-    -- Paste image to it's path
+    -- Paste image to its path
     paste_img_to(img_path(conf.img_dir, conf.img_name))
 
     -- Insert text


### PR DESCRIPTION
This commit should provide initial support for Mac OS. It requires [pngpaste](https://github.com/jcsalterego/pngpaste) to work.

Is the doc file generated automatically from the README? If so, could you please tell me how? If not, I'll update it as well. 