### PR TITLE
Adding a way to overrride the default image name on paste.

### DIFF
--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -118,6 +118,14 @@ M.inset_txt = function(affix, path_txt)
   end
 end
 
+M.paste_img2 = function (name)
+    local conf = {}
+    if name then
+        conf.img_name = name
+    end
+    M.paste_img(conf)
+end
+
 M.paste_img = function (opts)
   -- Check wether clipboard content is image or not
   local content = get_clip_content(cmd_check)

--- a/plugin/clipboard-image.vim
+++ b/plugin/clipboard-image.vim
@@ -15,7 +15,7 @@ lua require'clipboard-image'.setup()
 let g:clipboard_image_loaded = 1
 
 " Create vim command
-command! PasteImg :lua require'clipboard-image.paste'.paste_img()
+command! -nargs=1 PasteImg :lua require'clipboard-image.paste'.paste_img2("<args>")
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Hi there I'm loving your plugin alot. I wanted a way to name the image on paste so I added some code to do that.

Its a little bit tacked on and messy but please consider incorporating this feature if you don't like the code.
