### PR TITLE
feat: picker for existed image file

### DIFF
--- a/lua/clipboard-image/config.lua
+++ b/lua/clipboard-image/config.lua
@@ -1,6 +1,14 @@
 local M = {}
 
 M.config = {
+  pickers = {
+    default = {
+      default_picker = 'cmdline'
+    },
+    telescope_fd = {
+      finder = 'find'
+    }
+  },
   default = {
     img_dir = 'img',
     img_dir_txt = 'img',

--- a/lua/clipboard-image/pick.lua
+++ b/lua/clipboard-image/pick.lua
@@ -1,0 +1,58 @@
+local M = {}
+local conf_utils = require 'clipboard-image.config'
+local utils = require 'clipboard-image.utils'
+
+M.pickers = {
+  default = function(opt, subcmds)
+    local picker = opt.default_picker
+    local opts = conf_utils.get_config().pickers[picker] or {}
+    M.pickers[picker](opts, subcmds)
+  end,
+  cmdline = function (opts, subcmds)
+    vim.fn.inputsave()
+    local filepath = vim.fn.input('Search: ', '', 'file')
+    vim.fn.inputrestore()
+    utils.pick(filepath)
+  end,
+  telescope_fd = function (opts, subcmds)
+    local actions = require 'telescope.actions'
+    local action_state = require 'telescope.actions.state'
+    local finder_cmds = {
+      find = {'find', '.', '-iregex', [[.*\.\(png\)$]]},
+      fd = {'fd', '--regex', [[.*.(png)$]]},
+      rg = {'rg', '--files', '--glob', [[*.{png}]], '.'},
+    }
+
+    require 'telescope.builtin'.find_files {
+      find_command = finder_cmds[opts.finder],
+      attach_mappings = function (prompt_bufnr)
+        actions.select_default:replace(function ()
+          local filepath = action_state.get_selected_entry()[1]
+
+          actions.close(prompt_bufnr)
+          utils.pick(filepath)
+        end)
+        return true
+      end
+    }
+  end
+}
+
+M.get_pickers_list = function (pickers)
+  local pickers = {}
+  for k in pairs(M.pickers) do
+    table.insert(pickers, k)
+  end
+  return pickers
+end
+
+M.register_picker = function (pickers)
+  M.pickers = conf_utils.merge_config(M.pickers, pickers)
+end
+
+M.pick = function (picker, ...)
+  local opts = conf_utils.get_config().pickers[picker] or {}
+  M.pickers[picker](opts, {...})
+end
+
+return M

--- a/lua/clipboard-image/utils.lua
+++ b/lua/clipboard-image/utils.lua
@@ -127,4 +127,13 @@ end
 
 M.insert_text = M.insert_txt
 
+M.pick = function (filepath)
+  local conf_utils = require 'clipboard-image.config'
+  local conf = conf_utils.get_usable_config()
+  ---Strip filename from dir path and extension
+  local filename = filepath:match("^.*/(.*)%..+$")
+  filename = M.get_img_path(conf.img_dir_txt, filename, 'txt')
+  M.insert_txt(conf.affix, filename)
+end
+
 return M

--- a/plugin/clipboard-image.vim
+++ b/plugin/clipboard-image.vim
@@ -14,8 +14,30 @@ endif
 lua require'clipboard-image'.setup()
 let g:clipboard_image_loaded = 1
 
+" Command completion
+function! s:pickers_list(n)
+  let l:pickerslist = luaeval('require("clipboard-image.pick").get_pickers_list()')
+  if a:n == 0 
+    return l:pickerslist
+  endif
+endfunction
+
+function! s:picker_completion(arg,line,pos)
+  let l = split(a:line[:a:pos-1], '\%(\%(\%(^\|[^\\]\)\\\)\@<!\s\)\+', 1)
+  let n = len(l) - index(l, 'PasteImgPickers') - 2
+  return s:pickers_list(n)
+endfunction
+
+function! s:picker_completion2(arg,line,pos)
+  let l = split(a:line[:a:pos-1], '\%(\%(\%(^\|[^\\]\)\\\)\@<!\s\)\+', 1)
+  let n = len(l) - index(l, 'PasteImgPick') - 1
+  return s:pickers_list(n)
+endfunction
+
 " Create vim command
 command! PasteImg :lua require'clipboard-image.paste'.paste_img()
+command! -nargs=* -complete=customlist,s:picker_completion PasteImgPickers :lua require'clipboard-image.pick'.pick(<f-args>)
+command! -nargs=* -complete=file PasteImgPick :PasteImgPickers default <f-args>
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
This plugin at first only intended to copy image from clipboard but recently I want reuse those images that have been copied. This pr will add two new commands: `:PasteImgPick` and `:PasteImgPickers`. Also currently the config will look like this:

```lua
{
  pickers = {
    default = {
      default_picker = 'cmdline'
    },
    telescope_fd = {
      finder = 'find'
    }
  },
  default = {<opts>},
  <filetype> = {<opts>}
}
```

The new config introduces `pickers` table. So the idea is user can create picker with `pick.register_pickers(<picker>)` and configure it through that `pickers` table. The current built-in pickers are `default`, `cmdline`, and `telescope_fd`.

`:PasteImgPickers` is to select your picker, like this `:PasteImgPickers telescope_fd`. While `:PasteImgPick` is just an alias of `:PasteImgPickers default`. From the above config, `:PasteImgPickers default` will run `:PasteImgPickers cmdline`.

Here is the demos:
> Note: I use [wilder](https://github.com/gelguy/wilder.nvim) in this demo

### Cmdline picker
![cmdline demo](https://user-images.githubusercontent.com/26477782/143518921-ceff8873-564c-48b1-b194-90b95eb3ff92.gif)

### Telescope_fd picker
![telescope_fd demo](https://user-images.githubusercontent.com/26477782/143519647-1732cdbf-fce7-4455-985a-e4210d3db4ca.gif)

</br>
So what do you think? If there's anything you don't like or you think can be implemented better, please tell me.
