### PR TITLE
fix: fix bug related to path_separator nil value

### DIFF
--- a/lua/clipboard-image/utils.lua
+++ b/lua/clipboard-image/utils.lua
@@ -69,8 +69,8 @@ end
 ---@param path_separator string
 ---@return string full_path
 M.resolve_dir = function(dirs, path_separator)
+  path_separator = path_separator or '/'
   if (type(dirs) == "table") then
-    path_separator = path_separator or '/'
     local full_path = ""
     for _, dir in pairs(dirs) do
       full_path = full_path .. vim.fn.expand(dir) .. path_separator


### PR DESCRIPTION
Hi,

this PR fixes a bug that I encountered after commit d335954 (I think this is the correct commit, I've just started using this plugin). With this commit I got the error:

```
E5108: Error executing lua ...start/clipboard-image.nvim/lua/clipboard-image/utils.lua:80: attempt to concatenate local 'path_separator' (a nil value)                                                              
stack traceback:                                                                                                                                                                                                    
        ...start/clipboard-image.nvim/lua/clipboard-image/utils.lua:80: in function 'resolve_dir'                                                                                                                   
        ...start/clipboard-image.nvim/lua/clipboard-image/utils.lua:108: in function 'get_img_path'                                                                                                                 
        ...start/clipboard-image.nvim/lua/clipboard-image/paste.lua:19: in function 'paste_img'                                                                                                                     
        [string ":lua"]:1: in main chunk
```

If the else branch in `M.resolve_dir` is encountered, which in my case was because `img_dir` was not a table (I used default configuration), `path_separator` would be nil and give this error.

Let me know if there is anything wrong with this PR :smile: 