### PR TITLE
fix: add support for XDG_SESSION_TYPE as tty

### DIFF
--- a/lua/clipboard-image/utils.lua
+++ b/lua/clipboard-image/utils.lua
@@ -22,6 +22,9 @@ M.get_clip_command = function ()
     elseif display_server == 'wayland' then
       cmd_check = 'wl-paste --list-types'
       cmd_paste = 'wl-paste --no-newline --type image/png > \'%s\''
+    elseif display_server == 'tty' then
+      cmd_check = 'xclip -selection clipboard -o -t TARGETS'
+      cmd_paste = 'xclip -selection clipboard -t image/png -o > \'%s\''
     end
   elseif this_os == 'Darwin' then
     cmd_check = 'pngpaste -b 2>&1'

--- a/lua/clipboard-image/utils.lua
+++ b/lua/clipboard-image/utils.lua
@@ -16,15 +16,12 @@ M.get_clip_command = function ()
   local this_os = M.get_os()
   if this_os == 'Linux' then
     local display_server = os.getenv('XDG_SESSION_TYPE')
-    if display_server == 'x11' then
+    if display_server == 'x11' or display_server == 'tty' then
       cmd_check = 'xclip -selection clipboard -o -t TARGETS'
       cmd_paste = 'xclip -selection clipboard -t image/png -o > \'%s\''
     elseif display_server == 'wayland' then
       cmd_check = 'wl-paste --list-types'
       cmd_paste = 'wl-paste --no-newline --type image/png > \'%s\''
-    elseif display_server == 'tty' then
-      cmd_check = 'xclip -selection clipboard -o -t TARGETS'
-      cmd_paste = 'xclip -selection clipboard -t image/png -o > \'%s\''
     end
   elseif this_os == 'Darwin' then
     cmd_check = 'pngpaste -b 2>&1'


### PR DESCRIPTION
Hello, this is a small fix that allowed this plugin to work in my environment.  Thank you for the plugin!

---
If you don't start X with a display manager like gdm, and just use
startx or similar, it seems your XDG_SESSION_TYPE will be 'tty', which
causes an error.  This adds a case to handle tty.