### PR TITLE
Image format and size as new options

### DIFF
--- a/API.md
+++ b/API.md
@@ -56,13 +56,14 @@ require 'clipboard-image.init'.setup()
 | `<file-type>` | [`img_opts`](#image-options) | Value of `img_opts` for specific filetype.<br> Run `:set filetype?` to get filetype name.<br>     |
 
 #### Image Options
-| Field         | Type                 | Default Value                                                                                       | Description                                                                                                            |
-|---------------|----------------------|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| `img_name`    | `string`, `function` | `function () return os.date('%Y-%m-%d-%H-%M-%S') end` <br>*Example result: `"2021-08-21-16-14-17"`* | Image's name                                                                                                           |
-| `img_dir`     | `string`, `function` | `"img"`                                                                                             | Directory to save the image                                                                                            |
-| `img_dir_txt` | `string`, `function` | `"img"`                                                                                             | Directory on the text/buffer.<br> Example: Your actual dir is `src/assets/img` but your dir on **text** or buffer is `/assets/img`   |
-|`img_handler`  | `function`           | `function(img)  end`                                                | Function that will handle image after pasted.<br>`img` is a table that contain image's `name` and `path`|
-| `affix`       | `string`, `function` | `default`: `"%s"`<br> `markdown`: `"![](%s)"`</br>`asciidoc`: `"image::%s[]"`                                                       | String that sandwiched the image's path                                                                                |
+| Field | Type | Default Value | Description |
+|---|---|---|---|
+| `img_name` | `string`, `function` | `function () return os.date('%Y-%m-%d-%H-%M-%S') end` <br>*Example result: `"2021-08-21-16-14-17"`* | Image's name |
+| `img_dir` | `string`, `function` | `"img"` | Directory to save the image |
+| `img_dir_txt` | `string`, `function` | `"img"` | Directory on the text/buffer.<br> Example: Your actual dir is `src/assets/img` but your dir on **text** or buffer is `/assets/img` |
+| `img_format` | `string`, `function` | `"png"` | Format of the pasted image. |
+| `img_handler` | `function` | `function(img)  end` | Function that will handle image after pasted.<br>`img` is a table that contain image's `name` and `path` |
+| `affix` | `string`, `function` | `default`: `"%s"`<br> `markdown`: `"![](%s)"`<br>`asciidoc`: `"image::%s[]"`<br>`org`: `"[[%s]]"` | String that sandwiched the image's path |
 
 ### Paste
 | Function    | Parameter                                | Return | Description |

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ require'clipboard-image'.setup {
   default = {
     img_dir = "images",
     img_name = function() return os.date('%Y-%m-%d-%H-%M-%S') end, -- Example result: "2021-04-13-10-04-18"
-    affix = "<\n  %s\n>" -- Multi lines affix
+    img_format = "jpg", -- Image will be pasted as JPG. NEW (PR #38)
+    affix = "<\n  %s\n>", -- Multi lines affix
   },
+
   -- You can create configuration for ceartain filetype by creating another field (markdown, in this case)
   -- If you're uncertain what to name your field to, you can run `lua print(vim.bo.filetype)`
   -- Missing options from `markdown` field will be replaced by options from `default` field
@@ -80,13 +82,14 @@ require'clipboard-image'.setup {
 }
 ```
 
-|Options|Default|Description|
+| Options | Default | Description |
 |---|---|---|
-|`img_dir`|`"img"`|Directory where the image from clipboard will be copied to|
-|`img_dir_txt`|`"img"`|Directory that will be inserted to buffer.<br> Example: Your actual dir is `src/assets/img` but your dir on **text** or buffer is `/assets/img`|
-|`img_name`|`function() return os.date('%Y-%m-%d-%H-%M-%S') end`|Image's name|
-|`img_handler`|`function(img)  end`|Function that will handle image after pasted.<br>`img` is a table that contain pasted image's `name` and `path`|
-|`affix`|`default`: `"%s"`</br>`markdown`: `"![](%s)"`</br>`asciidoc`: `"image::%s[]"`|String that sandwiched the image's path|
+| `img_dir` | `"img"` | Directory where the image from clipboard will be copied to |
+| `img_dir_txt` | `"img"` | Directory that will be inserted to buffer.<br> Example: Your actual dir is `src/assets/img` but your dir on **text** or buffer is `/assets/img` |
+| `img_name` | `function() return os.date('%Y-%m-%d-%H-%M-%S') end` | Image's name |
+| `img_format` | `"png"` | Format for the pasted image |
+| `img_handler` | `function(img)  end` | Function that will handle image after pasted.<br>`img` is a table that contain pasted image's `name` and `path` |
+| `affix` | `default`: `"%s"`<br>`markdown`: `"![](%s)"`<br>`asciidoc`: `"image::%s[]"`<br>`org`: `"[[%s]]"` | String that sandwiched the image's path |
 
 </details>
 

--- a/doc/clipboard-image.txt
+++ b/doc/clipboard-image.txt
@@ -1,4 +1,4 @@
-*clipboard-image*             for Neovim 0.5+        Last modified: 29 Dec 2021
+*clipboard-image*             for Neovim 0.8+        Last modified: 12 Nov 2022
 
 Author: Ghani Rafif
 Repo: <github.com/ekickx/clipboard-image.nvim>
@@ -17,6 +17,7 @@ CONTENTS                                             *clipboard-image-contents*
       4.2.1. Img Dir                           |clipboard-image-config-img_dir|
       4.2.2. Img Dir Txt                   |clipboard-image-config-img_dir_txt|
       4.2.3. Img Name                         |clipboard-image-config-img_name|
+      4.2.3. Img Format                     |clipboard-image-config-img_format|
       4.2.4. Img Handler                   |clipboard-image-config-img_handler|
       4.2.5. Affix                               |clipboard-image-config-affix|
   5. Tips                                                |clipboard-image-tips|
@@ -158,6 +159,27 @@ Options~
 	  end
 <
 	  Example result: "2021-04-13-10-04-18"
+
+                                              *clipboard-image-config-img_format*
+  img_format~
+	Format for the pasted image.
+
+	Type:~
+	  string
+
+	Default:~
+	  "png"
+
+	Note:
+	  It's possible to create custom paste commands for specific formats
+	  in your `init.lua` file.
+>
+:>>>>>>\  vim.api.nvim_create_user_command(
+:>>>>>>\    'PasteJPG',
+:>>>>>>\    function(opts) require'clipboard-image.paste'.paste_img({img_format='jpg'}) end,
+:>>>>>>\    { nargs = 0 }
+:>>>>>>\  )
+<
 
                                            *clipboard-image-config-img_handler*
   img_handler~

--- a/lua/clipboard-image/config.lua
+++ b/lua/clipboard-image/config.lua
@@ -9,12 +9,17 @@ M.config = {
     end,
     img_handler = function(img) end,
     affix = "%s",
+    img_format = "png",
+    img_size = nil,
   },
   asciidoc = {
     affix = "image::%s[]",
   },
   markdown = {
     affix = "![](%s)",
+  },
+  org = {
+    affix = "[[%s]]",
   },
 }
 
@@ -57,12 +62,18 @@ end
 ---@param config_toload table
 ---@return table loaded_config
 M.load_config = function(config_toload)
+  local img_format = M.load_opt(config_toload.img_format)
+  img_ext = "."..img_format
+  if img_format == "jpg" then img_format = "jpeg" end
   return {
     affix = M.load_opt(config_toload.affix),
     img_name = M.load_opt(config_toload.img_name),
     img_dir = M.load_opt(config_toload.img_dir),
     img_dir_txt = M.load_opt(config_toload.img_dir_txt),
     img_handler = config_toload.img_handler,
+    img_format = img_format,
+    img_ext = img_ext,
+    img_size = M.load_opt(config_toload.img_size),
   }
 end
 

--- a/lua/clipboard-image/config.lua
+++ b/lua/clipboard-image/config.lua
@@ -62,7 +62,7 @@ end
 ---@return table loaded_config
 M.load_config = function(config_toload)
   local img_format = M.load_opt(config_toload.img_format)
-  img_ext = "."..img_format
+  local img_ext = "."..img_format
   if img_format == "jpg" then img_format = "jpeg" end
   return {
     affix = M.load_opt(config_toload.affix),

--- a/lua/clipboard-image/config.lua
+++ b/lua/clipboard-image/config.lua
@@ -10,7 +10,6 @@ M.config = {
     img_handler = function(img) end,
     affix = "%s",
     img_format = "png",
-    img_size = nil,
   },
   asciidoc = {
     affix = "image::%s[]",
@@ -73,7 +72,6 @@ M.load_config = function(config_toload)
     img_handler = config_toload.img_handler,
     img_format = img_format,
     img_ext = img_ext,
-    img_size = M.load_opt(config_toload.img_size),
   }
 end
 

--- a/lua/clipboard-image/health.lua
+++ b/lua/clipboard-image/health.lua
@@ -1,6 +1,5 @@
 local M = {}
 local utils = require "clipboard-image.utils"
-local health = require "health"
 
 local packages = {
   x11 = { name = "xclip", binary = "xclip" },
@@ -48,11 +47,11 @@ end
 M.check = function()
   local is_dep_exist, report_msg = M.check_current_dep()
 
-  health.report_start "Checking dependencies"
+  vim.health.report_start "Checking dependencies"
   if is_dep_exist then
-    health.report_ok(report_msg)
+    vim.health.report_ok(report_msg)
   else
-    health.report_error(report_msg)
+    vim.health.report_error(report_msg)
   end
 end
 

--- a/lua/clipboard-image/health.lua
+++ b/lua/clipboard-image/health.lua
@@ -47,9 +47,9 @@ end
 M.check = function()
   local is_dep_exist, report_msg = M.check_current_dep()
 
-  vim.health.report_start "Checking dependencies"
+  vim.health.start("Checking dependencies")
   if is_dep_exist then
-    vim.health.report_ok(report_msg)
+    vim.health.ok(report_msg)
   else
     vim.health.report_error(report_msg)
   end

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -2,10 +2,14 @@ local M = {}
 local conf_utils = require "clipboard-image.config"
 local utils = require "clipboard-image.utils"
 local check_dependency = require("clipboard-image.health").check_current_dep
-local cmd_check, cmd_paste = utils.get_clip_command()
+local cmd_check, paste_img_to = utils.get_clip_command()
 
-local paste_img_to = function(path)
-  os.execute(string.format(cmd_paste, path))
+local resize_img = function(path, img_size)
+    os.execute(string.format(
+      'convert %s -quality 95 -resize "'..img_size..'>" %s',
+      path,
+      path
+    ))
 end
 
 M.paste_img = function(opts)
@@ -15,20 +19,23 @@ M.paste_img = function(opts)
     return false
   end
 
+  local conf_toload = conf_utils.get_usable_config()
+  conf_toload = conf_utils.merge_config(conf_toload, opts)
+  local conf = conf_utils.load_config(conf_toload)
+
   local content = utils.get_clip_content(cmd_check)
-  if utils.is_clipboard_img(content) ~= true then
+
+  if utils.is_clipboard_img(content, conf.img_format) ~= true then
     vim.notify("There is no image data in clipboard", vim.log.levels.ERROR)
   else
-    local conf_toload = conf_utils.get_usable_config()
-    conf_toload = conf_utils.merge_config(conf_toload, opts)
-
-    local conf = conf_utils.load_config(conf_toload)
-    local path = utils.get_img_path(conf.img_dir, conf.img_name)
-    local path_txt = utils.get_img_path(conf.img_dir_txt, conf.img_name, "txt")
+    local path = utils.get_img_path(conf.img_dir, conf.img_name, conf.img_ext)
+    local path_txt = utils.get_img_path(conf.img_dir_txt, conf.img_name, conf.img_ext, "txt")
 
     utils.create_dir(conf.img_dir)
-    paste_img_to(path)
-
+    paste_img_to(path, conf.img_format)
+    if conf.img_size ~= nil then
+      resize_img(path, conf.img_size)
+    end
     utils.insert_txt(conf.affix, path_txt)
 
     if type(conf.img_handler) == "function" then

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -4,14 +4,6 @@ local utils = require "clipboard-image.utils"
 local check_dependency = require("clipboard-image.health").check_current_dep
 local cmd_check, paste_img_to = utils.get_clip_command()
 
-local resize_img = function(path, img_size)
-    os.execute(string.format(
-      'convert "%s" -quality 95 -resize "'..img_size..'>" "%s"',
-      path,
-      path
-    ))
-end
-
 M.paste_img = function(opts)
   local is_dep_exist, deps_msg = check_dependency()
   if not is_dep_exist then
@@ -33,9 +25,6 @@ M.paste_img = function(opts)
 
     utils.create_dir(conf.img_dir)
     paste_img_to(path, conf.img_format)
-    if conf.img_size ~= nil then
-      resize_img(path, conf.img_size)
-    end
     utils.insert_txt(conf.affix, path_txt)
 
     if type(conf.img_handler) == "function" then

--- a/lua/clipboard-image/paste.lua
+++ b/lua/clipboard-image/paste.lua
@@ -6,7 +6,7 @@ local cmd_check, paste_img_to = utils.get_clip_command()
 
 local resize_img = function(path, img_size)
     os.execute(string.format(
-      'convert %s -quality 95 -resize "'..img_size..'>" %s',
+      'convert "%s" -quality 95 -resize "'..img_size..'>" "%s"',
       path,
       path
     ))

--- a/lua/clipboard-image/utils.lua
+++ b/lua/clipboard-image/utils.lua
@@ -17,7 +17,7 @@ end
 
 ---Get command to *check* and *paste* clipboard content
 ---@return string cmd_check, string cmd_paste
-M.get_clip_command = function(img_format)
+M.get_clip_command = function()
   local cmd_check
   local paste_img_to
   local this_os = M.get_os()
@@ -26,13 +26,13 @@ M.get_clip_command = function(img_format)
     if display_server == "x11" or display_server == "tty" then
       cmd_check = "xclip -selection clipboard -o -t TARGETS"
       paste_img_to = function(path, img_format)
-        cmd = "xclip -selection clipboard -t image/%s -o > '%s'"
+        local cmd = "xclip -selection clipboard -t image/%s -o > '%s'"
         os.execute(string.format(cmd, img_format, path))
       end
     elseif display_server == "wayland" then
       cmd_check = "wl-paste --list-types"
       paste_img_to = function(path, img_format)
-        cmd = "wl-paste --no-newline --type image/%s > '%s'"
+        local cmd = "wl-paste --no-newline --type image/%s > '%s'"
         os.execute(string.format(cmd, img_format, path))
       end
     end
@@ -42,14 +42,14 @@ M.get_clip_command = function(img_format)
       if img_format ~= "png" then
         vim.notify("The image format"..img_format.." is not supported in this platform.", vim.log.levels.ERROR)
       end
-      cmd = "pngpaste '%s'"
+      local cmd = "pngpaste '%s'"
       os.execute(string.format(cmd, path))
     end
   elseif this_os == "Windows" or this_os == "Wsl" then
     cmd_check = "Get-Clipboard -Format Image"
     cmd_check = 'powershell.exe "' .. cmd_check .. '"'
     paste_img_to = function(path, img_format)
-      cmd = "$content = " .. cmd_check .. ";$content.Save('%s', '%s')"
+      local cmd = "$content = " .. cmd_check .. ";$content.Save('%s', '%s')"
       cmd = 'powershell.exe "' .. cmd .. '"'
       os.execute(string.format(cmd, path, img_format))
     end

--- a/plugin/clipboard-image.vim
+++ b/plugin/clipboard-image.vim
@@ -16,6 +16,8 @@ let g:clipboard_image_loaded = 1
 
 " Create vim command
 command! PasteImg :lua require'clipboard-image.paste'.paste_img()
+command! PastePNG :lua require'clipboard-image.paste'.paste_img({img_format="png"})
+command! PasteJPG :lua require'clipboard-image.paste'.paste_img({img_format="jpg"})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/plugin/clipboard-image.vim
+++ b/plugin/clipboard-image.vim
@@ -16,8 +16,6 @@ let g:clipboard_image_loaded = 1
 
 " Create vim command
 command! PasteImg :lua require'clipboard-image.paste'.paste_img()
-command! PastePNG :lua require'clipboard-image.paste'.paste_img({img_format="png"})
-command! PasteJPG :lua require'clipboard-image.paste'.paste_img({img_format="jpg"})
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
First thanks for creating this very useful plugin.

I have made some modifications to the plugin to allow for alternative image formats and sizes. It is often the case that I want to include an image in JPEG format or in a different size since this can significantly reduce the file size. Also JPEG can be more suitable for photography as you can see from the [Adobe comparison](https://www.adobe.com/creativecloud/file-types/image/comparison/jpeg-vs-png.html). Thus, I added these options to the plugin.

In order to modify the format, the clipboard application must be able to accept a format parameter. This seems to be the case for the Linux and Windows executables. For MacOS, an error will be raised if the user requests a format different than PNG since the current implementation uses `pngpaste`. We could modify the implementation in MacOS to support different formats.

As for the image size, this PR uses the  [ImageMagick `convert`](https://imagemagick.org/script/convert.php) command to modify the image size. Image size modification could be implemented with the `img_handler` option, but I thought it would be an overkill for something so simple.